### PR TITLE
Fixed run_cpu to call qlua using relative path

### DIFF
--- a/run_cpu
+++ b/run_cpu
@@ -43,4 +43,4 @@ args="-framework $FRAMEWORK -game_path $game_path -name $agent_name -env $ENV -e
 echo $args
 
 cd dqn
-qlua train_agent.lua $args
+../torch/bin/qlua train_agent.lua $args


### PR DESCRIPTION
This fixes `run_cpu` to call `qlua` using relative path, as with `run_gpu`.
